### PR TITLE
Enable schema migrations for tenant1 and tenant2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ STOCKIFY implements **schema-based multi-tenancy** where each tenant (company) g
 - `global_trade` → Global Trade Solutions  
 - `artisan_crafts` → Artisan Crafts Co.
 - `tech_solutions` → Tech Solutions Inc.
+- `tenant1` → Sample Tenant 1
+- `tenant2` → Sample Tenant 2
 
 ### How It Works
 1. **Schema Creation**: Each tenant gets its own schema with identical table structures
@@ -112,6 +114,8 @@ You should see separate schemas with **tables in each schema** (not in PUBLIC):
 - `GLOBAL_TRADE` → app_user, product, tenant_config, flyway_schema_history_global_trade
 - `ARTISAN_CRAFTS` → app_user, product, tenant_config, flyway_schema_history_artisan_crafts
 - `TECH_SOLUTIONS` → app_user, product, tenant_config, flyway_schema_history_tech_solutions
+- `TENANT1` → app_user, product, tenant_config, flyway_schema_history_tenant1
+- `TENANT2` → app_user, product, tenant_config, flyway_schema_history_tenant2
 
 **Important**: Tables should NOT be in PUBLIC schema anymore. Each tenant has its own isolated table set.
 

--- a/docs/schema-migration-report.md
+++ b/docs/schema-migration-report.md
@@ -11,7 +11,7 @@
 ### 1. Multi-Tenant Flyway Configuration
 - **File**: `MultiTenantFlywayConfig.java`
 - **Purpose**: Applies migrations to all tenant schemas
-- **Schemas**: `PUBLIC`, `stockify`, `acme_corp`, `global_trade`, `artisan_crafts`, `tech_solutions`
+ - **Schemas**: `PUBLIC`, `stockify`, `acme_corp`, `global_trade`, `artisan_crafts`, `tech_solutions`, `tenant1`, `tenant2`
 - **Features**: 
   - Creates separate flyway history tables per schema
   - Handles schema creation automatically
@@ -20,13 +20,13 @@
 ### 2. Enhanced Application Properties
 ```properties
 # Multi-schema Flyway configuration
-spring.flyway.schemas=PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions
+spring.flyway.schemas=PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions,tenant1,tenant2
 spring.flyway.default-schema=PUBLIC
 spring.flyway.create-schemas=true
 spring.flyway.baseline-on-migrate=true
 
 # Pre-create schemas in H2 URL
-spring.datasource.url=jdbc:h2:mem:stockifydb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;CASE_INSENSITIVE_IDENTIFIERS=true;INIT=CREATE SCHEMA IF NOT EXISTS PUBLIC\\;CREATE SCHEMA IF NOT EXISTS stockify\\;CREATE SCHEMA IF NOT EXISTS acme_corp\\;CREATE SCHEMA IF NOT EXISTS global_trade\\;CREATE SCHEMA IF NOT EXISTS artisan_crafts\\;CREATE SCHEMA IF NOT EXISTS tech_solutions
+spring.datasource.url=jdbc:h2:mem:stockifydb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;CASE_INSENSITIVE_IDENTIFIERS=true;INIT=CREATE SCHEMA IF NOT EXISTS PUBLIC\\;CREATE SCHEMA IF NOT EXISTS stockify\\;CREATE SCHEMA IF NOT EXISTS acme_corp\\;CREATE SCHEMA IF NOT EXISTS global_trade\\;CREATE SCHEMA IF NOT EXISTS artisan_crafts\\;CREATE SCHEMA IF NOT EXISTS tech_solutions\;CREATE SCHEMA IF NOT EXISTS tenant1\;CREATE SCHEMA IF NOT EXISTS tenant2
 ```
 
 ### 3. Simplified Connection Providers

--- a/src/main/java/dev/oasis/stockify/config/DataLoader.java
+++ b/src/main/java/dev/oasis/stockify/config/DataLoader.java
@@ -56,7 +56,7 @@ public class DataLoader implements CommandLineRunner {
     // Configuration for tenant setup - Real company-based tenant schemas
     // Note: 'stockify' tenant is reserved for super admin and created by SuperAdminInitializer
     private static final List<String> TENANT_IDS = Arrays.asList(
-        "stockify", "acme_corp", "global_trade", "artisan_crafts", "tech_solutions"
+        "stockify", "acme_corp", "global_trade", "artisan_crafts", "tech_solutions", "tenant1", "tenant2"
     );    // Sample data configurations
     private static final List<SampleUser> SAMPLE_USERS = Arrays.asList(
         new SampleUser("admin", "admin123", "ADMIN"),

--- a/src/main/java/dev/oasis/stockify/config/MultiTenantFlywayConfig.java
+++ b/src/main/java/dev/oasis/stockify/config/MultiTenantFlywayConfig.java
@@ -35,7 +35,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MultiTenantFlywayConfig implements CommandLineRunner {
 
-    @Value("${spring.flyway.schemas:PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions}")
+    @Value("${spring.flyway.schemas:PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions,tenant1,tenant2}")
     private String[] tenantSchemas;
 
     @Value("${spring.flyway.locations:classpath:db/migration}")

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 # H2 Database Configuration for Schema-based Multi-tenancy
 spring.datasource.generate-unique-name=false
-spring.datasource.url=jdbc:h2:mem:stockifydb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;CASE_INSENSITIVE_IDENTIFIERS=true;INIT=CREATE SCHEMA IF NOT EXISTS PUBLIC\\;CREATE SCHEMA IF NOT EXISTS stockify\\;CREATE SCHEMA IF NOT EXISTS acme_corp\\;CREATE SCHEMA IF NOT EXISTS global_trade\\;CREATE SCHEMA IF NOT EXISTS artisan_crafts\\;CREATE SCHEMA IF NOT EXISTS tech_solutions
+spring.datasource.url=jdbc:h2:mem:stockifydb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;CASE_INSENSITIVE_IDENTIFIERS=true;INIT=CREATE SCHEMA IF NOT EXISTS PUBLIC\\;CREATE SCHEMA IF NOT EXISTS stockify\\;CREATE SCHEMA IF NOT EXISTS acme_corp\\;CREATE SCHEMA IF NOT EXISTS global_trade\\;CREATE SCHEMA IF NOT EXISTS artisan_crafts\\;CREATE SCHEMA IF NOT EXISTS tech_solutions\;CREATE SCHEMA IF NOT EXISTS tenant1\;CREATE SCHEMA IF NOT EXISTS tenant2
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -24,7 +24,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.clean-on-validation-error=true
-spring.flyway.schemas=PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions
+spring.flyway.schemas=PUBLIC,stockify,acme_corp,global_trade,artisan_crafts,tech_solutions,tenant1,tenant2
 spring.flyway.default-schema=PUBLIC
 spring.flyway.create-schemas=true
 spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
## Summary
- allow Flyway to migrate tenant1 and tenant2 schemas
- include sample tenants tenant1 and tenant2
- document the new schemas in README and docs

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684d696f2c148327b6ee042ab9bd83c1