### PR TITLE
Add superadmin statistics page

### DIFF
--- a/src/main/java/dev/oasis/stockify/controller/SuperAdminController.java
+++ b/src/main/java/dev/oasis/stockify/controller/SuperAdminController.java
@@ -275,6 +275,27 @@ public class SuperAdminController {
     }
 
     /**
+     * Tenant statistics page
+     */
+    @GetMapping("/statistics")
+    public String statisticsPage(Model model, Principal principal) {
+        log.info("📊 Super Admin '{}' accessing statistics page", principal.getName());
+
+        try {
+            model.addAttribute("availableTenants", superAdminService.getAvailableTenants());
+            model.addAttribute("currentUser", principal.getName());
+            return "superadmin/statistics";
+
+        } catch (Exception e) {
+            log.error("❌ Error loading statistics page: {}", e.getMessage(), e);
+            model.addAttribute("error", "Failed to load statistics page");
+            return "superadmin/statistics";
+        } finally {
+            superAdminService.clearTenantContext();
+        }
+    }
+
+    /**
      * Get tenant statistics API
      */
     @GetMapping("/api/statistics")

--- a/src/main/resources/templates/superadmin/statistics.html
+++ b/src/main/resources/templates/superadmin/statistics.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tenant Statistics - Super Admin - Stockify</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <style>
+        .super-admin-header {
+            background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+            color: white;
+            padding: 2rem 0;
+        }
+        .nav-pills .nav-link.active {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/superadmin/dashboard">
+                <i class="fas fa-crown me-2"></i>
+                Stockify Super Admin
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/superadmin/dashboard">
+                            <i class="fas fa-tachometer-alt me-1"></i>Dashboard
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/superadmin/tenants">
+                            <i class="fas fa-building me-1"></i>Tenants
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/superadmin/users">
+                            <i class="fas fa-users me-1"></i>All Users
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/superadmin/products">
+                            <i class="fas fa-boxes me-1"></i>All Products
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" href="/superadmin/statistics">
+                            <i class="fas fa-chart-bar me-1"></i>Statistics
+                        </a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown">
+                            <i class="fas fa-user-crown me-1"></i>
+                            <span th:text="${currentUser}">Super Admin</span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="/logout">
+                                <i class="fas fa-sign-out-alt me-1"></i>Logout
+                            </a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="super-admin-header">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-8">
+                    <h1 class="display-4 mb-0">
+                        <i class="fas fa-chart-bar me-3"></i>
+                        Tenant Statistics
+                    </h1>
+                    <p class="lead mb-0">Detailed cross-tenant metrics</p>
+                </div>
+                <div class="col-md-4 text-end">
+                    <div class="card bg-primary text-white">
+                        <div class="card-body text-center">
+                            <h3 th:text="${#sets.size(availableTenants)}">0</h3>
+                            <small>Total Tenants</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container my-5">
+        <div class="table-responsive">
+            <table class="table table-striped align-middle" id="statsTable">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Tenant</th>
+                        <th>Users</th>
+                        <th>Active Users</th>
+                        <th>Products</th>
+                        <th>Low Stock</th>
+                        <th>Total Stock Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Rows will be populated by JS -->
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer class="bg-dark text-white text-center py-4 mt-5">
+        <div class="container">
+            <p class="mb-0">
+                <i class="fas fa-crown me-2"></i>
+                Stockify Super Admin Dashboard &copy; 2025
+            </p>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', loadStats);
+
+        function loadStats() {
+            fetch('/superadmin/api/statistics')
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        renderTable(data.data);
+                    }
+                })
+                .catch(err => console.error('Failed to load stats', err));
+        }
+
+        function renderTable(stats) {
+            const tbody = document.querySelector('#statsTable tbody');
+            tbody.innerHTML = '';
+            Object.keys(stats).forEach(tenant => {
+                const t = stats[tenant];
+                const row = document.createElement('tr');
+                if (t.error) {
+                    row.innerHTML = `<td>${tenant}</td><td colspan="5" class="text-danger">${t.error}</td>`;
+                } else {
+                    row.innerHTML = `
+                        <td>${tenant}</td>
+                        <td>${t.userCount}</td>
+                        <td>${t.activeUserCount}</td>
+                        <td>${t.productCount}</td>
+                        <td>${t.lowStockProductCount}</td>
+                        <td>$${Number(t.totalStockValue).toFixed(2)}</td>`;
+                }
+                tbody.appendChild(row);
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new statistics page template for superadmins
- expose `/superadmin/statistics` page from controller

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f552772048327847b8fe2ece97814