### PR TITLE
Use username for sign-up

### DIFF
--- a/src/main/java/dev/oasis/stockify/controller/RegisterController.java
+++ b/src/main/java/dev/oasis/stockify/controller/RegisterController.java
@@ -48,7 +48,7 @@ public class RegisterController {
                                     RedirectAttributes redirectAttributes,
                                     Model model) {
         
-        log.info("🎯 Processing registration for email: {}", registerRequest.getEmail());
+        log.info("🎯 Processing registration for username: {}", registerRequest.getUsername());
         
         // Check for validation errors
         if (bindingResult.hasErrors()) {
@@ -86,11 +86,13 @@ public class RegisterController {
             return "redirect:/login?registered=true&tenantId=" + registrationResult.getTenantId();
             
         } catch (Exception e) {
-            log.error("❌ Registration failed for {}: {}", registerRequest.getEmail(), e.getMessage());
-            
+            log.error("❌ Registration failed for {}: {}", registerRequest.getUsername(), e.getMessage());
+
             String errorMessage = e.getMessage();
             if (errorMessage.contains("email") && errorMessage.contains("kayıtlı")) {
                 bindingResult.rejectValue("email", "email.exists", errorMessage);
+            } else if (errorMessage.contains("kullanıcı") && errorMessage.contains("kayıtlı")) {
+                bindingResult.rejectValue("username", "username.exists", errorMessage);
             } else {
                 model.addAttribute("errorMessage", "Kayıt işlemi başarısız: " + errorMessage);
             }
@@ -112,6 +114,20 @@ public class RegisterController {
             return !registrationService.isEmailAlreadyRegistered(email);
         } catch (Exception e) {
             log.warn("Could not check email availability: {}", e.getMessage());
+            return true; // Assume available if check fails
+        }
+    }
+
+    /**
+     * AJAX endpoint to check if username is already registered
+     */
+    @GetMapping("/register/check-username")
+    @ResponseBody
+    public boolean checkUsernameAvailability(@RequestParam String username) {
+        try {
+            return !registrationService.isUsernameAlreadyRegistered(username);
+        } catch (Exception e) {
+            log.warn("Could not check username availability: {}", e.getMessage());
             return true; // Assume available if check fails
         }
     }

--- a/src/main/java/dev/oasis/stockify/dto/RegisterRequestDTO.java
+++ b/src/main/java/dev/oasis/stockify/dto/RegisterRequestDTO.java
@@ -28,6 +28,10 @@ public class RegisterRequestDTO {
     @NotBlank(message = "Şirket adı boş olamaz")
     @Size(min = 2, max = 100, message = "Şirket adı 2 ile 100 karakter arasında olmalıdır")
     private String companyName;
+
+    @NotBlank(message = "Kullanıcı adı boş olamaz")
+    @Size(min = 3, max = 20, message = "Kullanıcı adı 3 ile 20 karakter arasında olmalıdır")
+    private String username;
     
     @NotBlank(message = "E-posta adresi boş olamaz")
     @Email(message = "Geçerli bir e-posta adresi giriniz")
@@ -45,12 +49,4 @@ public class RegisterRequestDTO {
     
     @Builder.Default
     private Boolean acceptTerms = false;
-    
-    // Helper method to generate username from email
-    public String generateUsername() {
-        if (email != null && email.contains("@")) {
-            return email.substring(0, email.indexOf("@")).toLowerCase();
-        }
-        return null;
-    }
 }

--- a/src/main/java/dev/oasis/stockify/service/RegistrationService.java
+++ b/src/main/java/dev/oasis/stockify/service/RegistrationService.java
@@ -45,9 +45,13 @@ public class RegistrationService {
             if (isEmailAlreadyRegistered(registerRequest.getEmail())) {
                 throw new RuntimeException("Bu e-posta adresi zaten kayıtlı");
             }
-            
-            // Generate unique username from email
-            String username = generateUniqueUsername(registerRequest.getEmail());
+
+            // Check if username already exists
+            if (appUserService.existsByUsername(registerRequest.getUsername())) {
+                throw new RuntimeException("Bu kullanıcı adı zaten kayıtlı");
+            }
+
+            String username = registerRequest.getUsername();
             
             // Create tenant
             TenantCreateDTO tenantCreateDTO = TenantCreateDTO.builder()
@@ -88,26 +92,19 @@ public class RegistrationService {
             return false;
         }
     }
-    
+
     /**
-     * Generate unique username from email
+     * Check if username is already registered across all tenants
      */
-    private String generateUniqueUsername(String email) {
-        String baseUsername = email.substring(0, email.indexOf("@")).toLowerCase();
-        String username = baseUsername;
-        int counter = 1;
-        
-        // Check if username exists and increment if needed
-        while (appUserService.existsByUsername(username)) {
-            username = baseUsername + counter;
-            counter++;
-            if (counter > 100) { // Safety check
-                throw new RuntimeException("Kullanıcı adı oluşturulamadı");
-            }
+    public boolean isUsernameAlreadyRegistered(String username) {
+        try {
+            return appUserService.existsByUsername(username);
+        } catch (Exception e) {
+            log.warn("Could not check username existence: {}", e.getMessage());
+            return false;
         }
-        
-        return username;
     }
+    
       /**
      * Get plan features for display
      */

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -35,18 +35,18 @@
                             </div>
                         </div>                        <div class="mb-3">
                             <label for="username" class="form-label">
-                                Kullanıcı Adı veya E-posta
+                                Kullanıcı Adı
                             </label>
                             <input type="text"
                                    class="form-control"
                                    id="username"
                                    name="username"
-                                   placeholder="Kullanıcı adı veya e-posta adresiniz"
+                                   placeholder="Kullanıcı adınız"
                                    required
                                    autocomplete="off">
                             <div class="form-text">
-                                <i class="bi bi-info-circle"></i> 
-                                Kayıt sırasında kullandığınız kullanıcı adı veya e-posta ile giriş yapabilirsiniz.
+                                <i class="bi bi-info-circle"></i>
+                                Kayıt sırasında belirlediğiniz kullanıcı adı ile giriş yapın.
                             </div>
                         </div>
 

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -282,6 +282,18 @@
               </div>
 
               <div class="mb-3">
+                <label for="username" class="form-label">Kullanıcı Adı</label>
+                <input type="text" class="form-control" id="username" th:field="*{username}"
+                  th:classappend="${#fields.hasErrors('username')} ? 'is-invalid'" required />
+                <div th:if="${#fields.hasErrors('username')}" class="invalid-feedback">
+                  <span th:errors="*{username}"></span>
+                </div>
+                <div class="form-text" id="usernameHelp">
+                  Girişte kullanacağınız benzersiz kullanıcı adı
+                </div>
+              </div>
+
+              <div class="mb-3">
                 <label for="email" class="form-label">E-posta Adresi</label>
                 <input type="email" class="form-control" id="email" th:field="*{email}"
                   th:classappend="${#fields.hasErrors('email')} ? 'is-invalid'" required />
@@ -289,7 +301,7 @@
                   <span th:errors="*{email}"></span>
                 </div>
                 <div class="form-text" id="emailHelp">
-                  Bu e-posta adresi ile giriş yapacaksınız
+                  Bildirimler için e-posta adresiniz
                 </div>
               </div>
 
@@ -393,6 +405,28 @@
           '<i class="fas fa-spinner fa-spin me-2"></i>Hesap Oluşturuluyor...';
       });
 
+    // Username validation
+    document.getElementById("username").addEventListener("blur", function () {
+      const username = this.value;
+      if (username && username.length >= 3) {
+        fetch(`/register/check-username?username=${encodeURIComponent(username)}`)
+          .then((response) => response.json())
+          .then((available) => {
+            const usernameHelp = document.getElementById("usernameHelp");
+            if (!available) {
+              usernameHelp.innerHTML = '<span class="text-danger">Bu kullanıcı adı zaten kullanılıyor</span>';
+              this.classList.add("is-invalid");
+            } else {
+              usernameHelp.innerHTML = "Girişte kullanacağınız benzersiz kullanıcı adı";
+              this.classList.remove("is-invalid");
+            }
+          })
+          .catch(() => {
+            // Ignore errors in username check
+          });
+      }
+    });
+
     // Email validation
     document.getElementById("email").addEventListener("blur", function () {
       const email = this.value;
@@ -407,7 +441,7 @@
               this.classList.add("is-invalid");
             } else {
               emailHelp.innerHTML =
-                "Bu e-posta adresi ile giriş yapacaksınız";
+                "Bildirimler için e-posta adresiniz";
               this.classList.remove("is-invalid");
             }
           })


### PR DESCRIPTION
## Summary
- add username to registration request DTO
- update registration service to check usernames
- improve register controller with username validation
- update registration form to request username
- adjust login form to accept username only

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685db45e2ee88327952947ad01e48b80