### PR TITLE
Fix notification badge display

### DIFF
--- a/src/main/resources/templates/admin/categories.html
+++ b/src/main/resources/templates/admin/categories.html
@@ -77,7 +77,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/category-form.html
+++ b/src/main/resources/templates/admin/category-form.html
@@ -77,7 +77,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -82,7 +82,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>
@@ -683,7 +683,7 @@
                                 <a href="/admin/notifications" class="btn btn-outline-warning w-100">
                                     <i class="bi bi-bell d-block mb-1"></i>
                                     <small>Bildirimler</small>
-                                    <span class="badge bg-danger position-absolute top-0 start-100 translate-middle" id="quickActionNotificationBadge" style="display: none;">0</span>
+                                    <span class="badge bg-danger position-absolute top-0 start-100 translate-middle" id="quickActionNotificationBadge" style="display: inline;">1</span>
                                 </a>
                             </div>
                             <div class="col-md-2 col-sm-4 col-6">

--- a/src/main/resources/templates/admin/notifications.html
+++ b/src/main/resources/templates/admin/notifications.html
@@ -147,7 +147,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge"
                                     th:if="${unreadNotifications > 0}" th:text="${unreadNotifications}"
-                                    style="display: none;">0</span>
+                                    style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -74,7 +74,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/products.html
+++ b/src/main/resources/templates/admin/products.html
@@ -78,7 +78,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/stock-movements.html
+++ b/src/main/resources/templates/admin/stock-movements.html
@@ -87,7 +87,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/user-form.html
+++ b/src/main/resources/templates/admin/user-form.html
@@ -93,7 +93,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -79,7 +79,7 @@
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
                                       th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: none;">0</span>
+                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- show notification badge by default across admin templates

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685dbbd03750832787028603ecbc9b7a