### PR TITLE
Fix missing notification badge on admin pages

### DIFF
--- a/src/main/java/dev/oasis/stockify/advice/NotificationBadgeAdvice.java
+++ b/src/main/java/dev/oasis/stockify/advice/NotificationBadgeAdvice.java
@@ -1,0 +1,31 @@
+package dev.oasis.stockify.advice;
+
+import dev.oasis.stockify.service.StockNotificationService;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.ui.Model;
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice(basePackages = "dev.oasis.stockify.controller")
+public class NotificationBadgeAdvice {
+
+    private final StockNotificationService stockNotificationService;
+
+    public NotificationBadgeAdvice(StockNotificationService stockNotificationService) {
+        this.stockNotificationService = stockNotificationService;
+    }
+
+    @ModelAttribute
+    public void addUnreadNotifications(Model model, HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (!uri.startsWith("/admin")) {
+            return;
+        }
+        try {
+            long unread = stockNotificationService.getUnreadNotifications().size();
+            model.addAttribute("unreadNotifications", unread);
+        } catch (Exception e) {
+            model.addAttribute("unreadNotifications", 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `NotificationBadgeAdvice` that exposes `unreadNotifications` model attribute for all admin controllers

## Testing
- `./mvnw -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dc22a16888327906a035bf632520c