### PR TITLE
Fix notification badge rendering via service calls

### DIFF
--- a/src/main/resources/templates/admin/categories.html
+++ b/src/main/resources/templates/admin/categories.html
@@ -32,8 +32,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -76,8 +76,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/category-form.html
+++ b/src/main/resources/templates/admin/category-form.html
@@ -32,8 +32,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -76,8 +76,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -37,8 +37,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -81,8 +81,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>
@@ -877,7 +877,7 @@
         // Notification System Integration - Get initial data from server
         let notificationData = {
             total: /*[[${totalNotifications}]]*/ 12,
-            unread: /*[[${unreadNotifications}]]*/ 3,
+            unread: /*[[${@stockNotificationService.getUnreadNotifications().size()}]]*/ 3,
             critical: /*[[${criticalNotifications}]]*/ 2,
             alerts: [
                 { 

--- a/src/main/resources/templates/admin/notifications.html
+++ b/src/main/resources/templates/admin/notifications.html
@@ -102,8 +102,8 @@
                 <a class="nav-link position-relative me-3" href="/admin/notifications" title="Notifications">
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                        id="navNotificationBadge" th:if="${unreadNotifications > 0}"
-                        th:text="${unreadNotifications}">0</span>
+                        id="navNotificationBadge" th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                        th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i>
@@ -146,7 +146,7 @@
                             <a class="nav-link active" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge"
-                                    th:if="${unreadNotifications > 0}" th:text="${unreadNotifications}"
+                                    th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}" th:text="${@stockNotificationService.getUnreadNotifications().size()}"
                                     style="display: inline;">1</span>
                             </a>
                         </li>
@@ -194,7 +194,7 @@
                                 <div class="d-flex justify-content-between">
                                     <div>
                                         <h6 class="card-title text-muted">Unread</h6>
-                                        <h3 class="mb-0" id="unreadNotifications" th:text="${unreadNotifications ?: 0}">
+                                        <h3 class="mb-0" id="unreadNotifications" th:text="${@stockNotificationService.getUnreadNotifications().size()}">
                                             0</h3>
                                     </div>
                                     <div class="text-warning">

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -30,8 +30,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -73,8 +73,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/products.html
+++ b/src/main/resources/templates/admin/products.html
@@ -34,8 +34,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -77,8 +77,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/stock-movements.html
+++ b/src/main/resources/templates/admin/stock-movements.html
@@ -43,8 +43,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -86,8 +86,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/user-form.html
+++ b/src/main/resources/templates/admin/user-form.html
@@ -48,8 +48,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -92,8 +92,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -35,8 +35,8 @@
                     <i class="bi bi-bell"></i>
                     <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" 
                           id="navNotificationBadge" 
-                          th:if="${unreadNotifications > 0}"
-                          th:text="${unreadNotifications}">0</span>
+                          th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                          th:text="${@stockNotificationService.getUnreadNotifications().size()}">0</span>
                 </a>
                 <span class="navbar-text me-3">
                     <i class="bi bi-building"></i> 
@@ -78,8 +78,8 @@
                             <a class="nav-link" href="/admin/notifications">
                                 <i class="bi bi-bell"></i> Notifications
                                 <span class="badge bg-danger ms-2" id="notificationBadge" 
-                                      th:if="${unreadNotifications > 0}"
-                                      th:text="${unreadNotifications}" style="display: inline;">1</span>
+                                      th:if="${@stockNotificationService.getUnreadNotifications().size() > 0}"
+                                      th:text="${@stockNotificationService.getUnreadNotifications().size()}" style="display: inline;">1</span>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- remove NotificationBadgeAdvice
- reference StockNotificationService directly in admin templates so unread count shows everywhere

## Testing
- `./mvnw -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dc22a16888327906a035bf632520c