### PR TITLE
Add low stock check after stock movements

### DIFF
--- a/src/main/java/dev/oasis/stockify/service/ProductService.java
+++ b/src/main/java/dev/oasis/stockify/service/ProductService.java
@@ -257,9 +257,6 @@ public class ProductService {
                     Product savedProduct = productRepository.findById(productId)
                         .orElseThrow(() -> new RuntimeException("Product not found after stock movement"));
                     
-                    // Check for low stock notifications
-                    stockNotificationService.checkAndCreateLowStockNotification(savedProduct);
-                    
                     log.info("✅ Quick restock completed - Product: {} Old Stock: {} New Stock: {} for tenant: {}", 
                             savedProduct.getTitle(), oldStockLevel, savedProduct.getStockLevel(), currentTenant);
                     

--- a/src/main/java/dev/oasis/stockify/service/StockMovementService.java
+++ b/src/main/java/dev/oasis/stockify/service/StockMovementService.java
@@ -10,6 +10,7 @@ import dev.oasis.stockify.model.StockMovement;
 import dev.oasis.stockify.repository.AppUserRepository;
 import dev.oasis.stockify.repository.ProductRepository;
 import dev.oasis.stockify.repository.StockMovementRepository;
+import dev.oasis.stockify.service.StockNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -44,6 +45,7 @@ public class StockMovementService {
     private final StockMovementRepository stockMovementRepository;
     private final ProductRepository productRepository;
     private final AppUserRepository appUserRepository;
+    private final StockNotificationService stockNotificationService;
 
     /**
      * Create a new stock movement
@@ -94,6 +96,7 @@ public class StockMovementService {
         // Update product stock level
         product.setStockLevel(newStock);
         productRepository.save(product);
+        stockNotificationService.checkAndCreateLowStockNotification(product);
 
         log.info(
                 "✅ Stock movement created - Product: {}, Type: {}, Quantity: {}, Previous: {} -> New: {} for tenant: {}",


### PR DESCRIPTION
## Summary
- trigger low stock notifications in `StockMovementService`
- avoid duplicate notification check in quick restock

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686191f3ca0c83279778de2fdca8139b