### PR TITLE
Fix product metrics refresh

### DIFF
--- a/src/main/java/dev/oasis/stockify/controller/AdminDashboardController.java
+++ b/src/main/java/dev/oasis/stockify/controller/AdminDashboardController.java
@@ -22,6 +22,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -113,6 +114,12 @@ public class AdminDashboardController {
         model.addAttribute("currentTenantId", currentTenantId);
         
         return "admin/dashboard";
+    }
+
+    @GetMapping("/metrics")
+    @ResponseBody
+    public DashboardMetricsDTO getMetrics() {
+        return dashboardService.getDashboardMetrics();
     }
     
     /**

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -177,7 +177,7 @@
                                 <div class="d-flex justify-content-between">
                                     <div>
                                         <h6 class="card-title text-muted">Total Products</h6>
-                                        <h3 class="mb-0" th:text="${totalProducts ?: 0}">0</h3>
+                                        <h3 class="mb-0" id="totalProductsCount" th:text="${totalProducts ?: 0}">0</h3>
                                     </div>
                                     <div class="text-primary">
                                         <i class="bi bi-box-seam display-6"></i>
@@ -185,7 +185,7 @@
                                 </div>
                                 <div class="mt-2">
                                     <small class="text-success">
-                                        <i class="bi bi-arrow-up"></i> <span th:text="${activeProducts ?: 0}">0</span>
+                                        <i class="bi bi-arrow-up"></i> <span id="activeProductsCount" th:text="${activeProducts ?: 0}">0</span>
                                         Active
                                     </small>
                                 </div>
@@ -198,7 +198,7 @@
                                 <div class="d-flex justify-content-between">
                                     <div>
                                         <h6 class="card-title text-muted">Total Users</h6>
-                                        <h3 class="mb-0" th:text="${totalUsers ?: 0}">0</h3>
+                                        <h3 class="mb-0" id="totalUsersCount" th:text="${totalUsers ?: 0}">0</h3>
                                     </div>
                                     <div class="text-success">
                                         <i class="bi bi-people-fill display-6"></i>
@@ -206,7 +206,7 @@
                                 </div>
                                 <div class="mt-2">
                                     <small class="text-info">
-                                        <i class="bi bi-shield"></i> <span th:text="${adminUsers ?: 0}">0</span> Admins
+                                        <i class="bi bi-shield"></i> <span id="adminUsersCount" th:text="${adminUsers ?: 0}">0</span> Admins
                                     </small>
                                 </div>
                             </div>
@@ -219,7 +219,7 @@
                                 <div class="d-flex justify-content-between">
                                     <div>
                                         <h6 class="card-title text-muted">Low Stock</h6>
-                                        <h3 class="mb-0 text-warning" th:text="${lowStockProducts ?: 0}">0</h3>
+                                        <h3 class="mb-0 text-warning" id="lowStockProductsCount" th:text="${lowStockProducts ?: 0}">0</h3>
                                     </div>
                                     <div class="text-warning">
                                         <i class="bi bi-exclamation-triangle-fill display-6"></i>
@@ -618,10 +618,11 @@
         <script th:inline="javascript">
             // Product Chart
             const ctx = document.getElementById('productChart').getContext('2d');
-            const totalProducts = /*[[${totalProducts ?: 0}]]*/ 0;
-            const activeProducts = /*[[${activeProducts ?: 0}]]*/ 0;
-            const lowStockProducts = /*[[${lowStockProducts ?: 0}]]*/ 0;
-            const outOfStockProducts = /*[[${outOfStockProducts ?: 0}]]*/ 0;
+            const tenantId = /*[[${currentTenantId}]]*/ 'public';
+            let totalProducts = /*[[${totalProducts ?: 0}]]*/ 0;
+            let activeProducts = /*[[${activeProducts ?: 0}]]*/ 0;
+            let lowStockProducts = /*[[${lowStockProducts ?: 0}]]*/ 0;
+            let outOfStockProducts = /*[[${outOfStockProducts ?: 0}]]*/ 0;
 
             const productChart = new Chart(ctx, {
                 type: 'doughnut',
@@ -658,6 +659,36 @@
                     }
                 }
             });
+
+            async function refreshMetrics() {
+                try {
+                    const response = await fetch('/admin/dashboard/metrics', {
+                        headers: { 'X-TenantId': tenantId }
+                    });
+                    if (!response.ok) return;
+                    const data = await response.json();
+
+                    totalProducts = data.totalProducts;
+                    activeProducts = Math.max(0, data.totalProducts - data.lowStockProducts);
+                    lowStockProducts = data.lowStockProducts;
+
+                    document.getElementById('totalProductsCount').innerText = totalProducts;
+                    document.getElementById('activeProductsCount').innerText = activeProducts;
+                    document.getElementById('lowStockProductsCount').innerText = lowStockProducts;
+
+                    productChart.data.datasets[0].data = [
+                        activeProducts,
+                        Math.max(0, totalProducts - activeProducts),
+                        lowStockProducts,
+                        outOfStockProducts
+                    ];
+                    productChart.update();
+                } catch (e) {
+                    console.error('Failed to refresh metrics', e);
+                }
+            }
+
+            setInterval(refreshMetrics, 5000);
         </script>
 
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- expose new metrics API endpoint
- auto-refresh dashboard product stats via AJAX

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861b0119bbc8327bea449f17db23dd3