### PR TITLE
Fix active product count

### DIFF
--- a/src/main/java/dev/oasis/stockify/controller/AdminDashboardController.java
+++ b/src/main/java/dev/oasis/stockify/controller/AdminDashboardController.java
@@ -86,7 +86,7 @@ public class AdminDashboardController {
         
         // Add individual metrics for template
         model.addAttribute("totalProducts", metrics.getTotalProducts());
-        model.addAttribute("activeProducts", Math.max(0, metrics.getTotalProducts() - metrics.getLowStockProducts()));
+        model.addAttribute("activeProducts", metrics.getActiveProducts());
         model.addAttribute("lowStockProducts", metrics.getLowStockProducts());
         model.addAttribute("outOfStockProducts", 0L); // TODO: Add to DashboardMetricsDTO
         model.addAttribute("totalUsers", tenantUsers.size());

--- a/src/main/java/dev/oasis/stockify/controller/UserDashboardController.java
+++ b/src/main/java/dev/oasis/stockify/controller/UserDashboardController.java
@@ -75,7 +75,7 @@ public class UserDashboardController {
 
         // Add individual metrics for template
         model.addAttribute("totalProducts", metrics.getTotalProducts());
-        model.addAttribute("activeProducts", Math.max(0, metrics.getTotalProducts() - metrics.getLowStockProducts()));
+        model.addAttribute("activeProducts", metrics.getActiveProducts());
         model.addAttribute("lowStockProducts", metrics.getLowStockProducts());
         model.addAttribute("outOfStockProducts", 0L); // TODO: Add to DashboardMetricsDTO
         model.addAttribute("totalInventoryValue", String.format("%.2f", metrics.getTotalInventoryValue()));

--- a/src/main/java/dev/oasis/stockify/dto/DashboardMetricsDTO.java
+++ b/src/main/java/dev/oasis/stockify/dto/DashboardMetricsDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DashboardMetricsDTO {
     private long totalProducts;
+    private long activeProducts;
     private long totalUsers;
     private double totalInventoryValue;
     private long lowStockProducts;

--- a/src/main/java/dev/oasis/stockify/repository/ProductRepository.java
+++ b/src/main/java/dev/oasis/stockify/repository/ProductRepository.java
@@ -27,6 +27,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.isActive = true")
     List<Product> findActiveProducts();
 
+    long countByIsActive(Boolean isActive);
+
      @Query("SELECT p FROM Product p WHERE p.category = :category")
     List<Product> findByCategory(@Param("category") String category);
     

--- a/src/main/java/dev/oasis/stockify/service/DashboardService.java
+++ b/src/main/java/dev/oasis/stockify/service/DashboardService.java
@@ -44,6 +44,7 @@ public class DashboardService {
         
         return DashboardMetricsDTO.builder()
                 .totalProducts(productCount)
+                .activeProducts(countActiveProducts())
                 .totalUsers(tenantUserCount)
                 .totalInventoryValue(calculateTotalInventoryValue())
                 .lowStockProducts(countLowStockProducts())
@@ -133,12 +134,19 @@ public class DashboardService {
     private long countLowStockProducts() {
         String currentTenant = TenantContext.getCurrentTenant();
         List<Product> products = productRepository.findAll();
-        log.debug("📦 Counting low stock products for tenant: {} - Total products: {}", 
+        log.debug("📦 Counting low stock products for tenant: {} - Total products: {}",
                  currentTenant, products.size());
-        
+
         return products.stream()
                 .filter(product -> product.getStockLevel() < product.getLowStockThreshold())
                 .count();
+    }
+
+    private long countActiveProducts() {
+        String currentTenant = TenantContext.getCurrentTenant();
+        long count = productRepository.countByIsActive(true);
+        log.debug("🔁 Counting active products for tenant: {} = {}", currentTenant, count);
+        return count;
     }
 
     private double getMonthlyRevenue() {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -630,7 +630,7 @@
                     labels: ['Active Products', 'Inactive Products', 'Low Stock', 'Out of Stock'],
                     datasets: [{
                         data: [
-                            Math.max(0, totalProducts - lowStockProducts - outOfStockProducts),
+                            activeProducts,
                             Math.max(0, totalProducts - activeProducts),
                             lowStockProducts,
                             outOfStockProducts
@@ -669,7 +669,7 @@
                     const data = await response.json();
 
                     totalProducts = data.totalProducts;
-                    activeProducts = Math.max(0, data.totalProducts - data.lowStockProducts);
+                    activeProducts = data.activeProducts;
                     lowStockProducts = data.lowStockProducts;
 
                     document.getElementById('totalProductsCount').innerText = totalProducts;


### PR DESCRIPTION
## Summary
- add `activeProducts` field to `DashboardMetricsDTO`
- count active products in `DashboardService`
- use new metric in admin and user dashboards
- show correct value in admin dashboard chart

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861b3c6f8808327b8df2d70eee72dde