### PR TITLE
Add bulk stock movement validation

### DIFF
--- a/src/main/java/dev/oasis/stockify/controller/StockMovementController.java
+++ b/src/main/java/dev/oasis/stockify/controller/StockMovementController.java
@@ -3,6 +3,7 @@ package dev.oasis.stockify.controller;
 import dev.oasis.stockify.dto.BulkStockMovementCreateDTO;
 import dev.oasis.stockify.dto.StockMovementCreateDTO;
 import dev.oasis.stockify.dto.StockMovementResponseDTO;
+import dev.oasis.stockify.dto.ValidationErrorDTO;
 import dev.oasis.stockify.model.StockMovement;
 import dev.oasis.stockify.service.StockMovementService;
 import dev.oasis.stockify.config.tenant.TenantContext;
@@ -89,6 +90,16 @@ public class StockMovementController {
         }
     }
 
+    @PostMapping("/validate")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> validateMovement(@RequestBody StockMovementCreateDTO dto) {
+        List<String> errors = stockMovementService.validateStockMovement(dto);
+        return ResponseEntity.ok(Map.of(
+                "valid", errors.isEmpty(),
+                "errors", errors
+        ));
+    }
+
     /**
      * Get stock movements by product (AJAX)
      */
@@ -150,6 +161,16 @@ public class StockMovementController {
         }
     }
 
+    @PostMapping("/bulk-validate")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> validateBulk(@RequestBody BulkStockMovementCreateDTO bulkDto) {
+        List<ValidationErrorDTO> errors = stockMovementService.validateBulkStockMovements(bulkDto);
+        return ResponseEntity.ok(Map.of(
+                "valid", errors.isEmpty(),
+                "errors", errors
+        ));
+    }
+
     /**
      * Toplu stok hareketi girişi
      */    
@@ -161,6 +182,20 @@ public class StockMovementController {
             return ResponseEntity.ok(Map.of("success", true, "message", "Başarıyla yüklendi"));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("success", false, "message", "Yükleme hatası: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/validate-csv")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> validateCsv(@RequestParam("file") MultipartFile file) {
+        try {
+            List<ValidationErrorDTO> errors = stockMovementService.validateCsv(file);
+            return ResponseEntity.ok(Map.of(
+                    "valid", errors.isEmpty(),
+                    "errors", errors
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("valid", false, "message", e.getMessage()));
         }
     }
 

--- a/src/main/java/dev/oasis/stockify/dto/ValidationErrorDTO.java
+++ b/src/main/java/dev/oasis/stockify/dto/ValidationErrorDTO.java
@@ -1,0 +1,11 @@
+package dev.oasis.stockify.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ValidationErrorDTO {
+    private int index;
+    private String message;
+}

--- a/src/main/resources/templates/admin/stock-movements.html
+++ b/src/main/resources/templates/admin/stock-movements.html
@@ -509,31 +509,39 @@
                 quantity: parseInt(formData.get('quantity')),
                 referenceId: formData.get('referenceId') || null,
                 notes: formData.get('notes') || null,
-                createdBy: null // Will be set by the server
+                createdBy: null
             };
 
-            fetch('/admin/stock-movements/create', {
+            fetch('/admin/stock-movements/validate', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data)
             })
-                .then(response => {
-                    if (response.ok) {
-                        return response.json();
+                .then(res => res.json())
+                .then(result => {
+                    if (!result.valid) {
+                        alert(result.errors.join('\n'));
+                        return;
                     }
+                    if (!confirm('Confirm and save?')) return;
+                    return fetch('/admin/stock-movements/create', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(data)
+                    });
+                })
+                .then(response => {
+                    if (!response) return;
+                    if (response.ok) return response.json();
                     throw new Error('Network response was not ok');
                 })
-                .then(data => {
-                    // Close modal and reload page
+                .then(() => {
                     const modal = bootstrap.Modal.getInstance(document.getElementById('createMovementModal'));
                     modal.hide();
                     location.reload();
                 })
                 .catch(error => {
-                    console.error('Error:', error);
-                    alert('Error creating stock movement: ' + error.message);
+                    if (error) alert('Error creating stock movement: ' + error.message);
                 });
         }
 
@@ -571,22 +579,37 @@
                 }
             });
 
-            fetch('/admin/stock-movements/bulk-create', {
+            fetch('/admin/stock-movements/bulk-validate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ movements })
             })
+                .then(res => res.json())
+                .then(result => {
+                    if (!result.valid) {
+                        const msgs = result.errors.map(e => 'Row ' + (e.index + 1) + ': ' + e.message);
+                        alert(msgs.join('\n'));
+                        return;
+                    }
+                    if (!confirm('Confirm and save all?')) return;
+                    return fetch('/admin/stock-movements/bulk-create', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ movements })
+                    });
+                })
                 .then(response => {
+                    if (!response) return;
                     if (response.ok) return response.json();
                     throw new Error('Network response was not ok');
                 })
-                .then(data => {
+                .then(() => {
                     const modal = bootstrap.Modal.getInstance(document.getElementById('createBulkMovementModal'));
                     modal.hide();
                     location.reload();
                 })
                 .catch(error => {
-                    alert('Error creating bulk stock movements: ' + error.message);
+                    if (error) alert('Error creating bulk stock movements: ' + error.message);
                 });
         }
 
@@ -596,21 +619,35 @@
             const form = e.target;
             const formData = new FormData(form);
 
-            fetch('/admin/stock-movements/upload-csv', {
+            fetch('/admin/stock-movements/validate-csv', {
                 method: 'POST',
                 body: formData
             })
+                .then(res => res.json())
+                .then(result => {
+                    if (!result.valid) {
+                        const msgs = result.errors.map(e => 'Row ' + (e.index + 1) + ': ' + e.message);
+                        alert(msgs.join('\n'));
+                        return;
+                    }
+                    if (!confirm('Confirm upload?')) return;
+                    return fetch('/admin/stock-movements/upload-csv', {
+                        method: 'POST',
+                        body: formData
+                    });
+                })
                 .then(response => {
+                    if (!response) return;
                     if (response.ok) return response.json();
                     throw new Error('Network response was not ok');
                 })
-                .then(data => {
+                .then(() => {
                     const modal = bootstrap.Modal.getInstance(document.getElementById('uploadCsvModal'));
                     modal.hide();
                     location.reload();
                 })
                 .catch(error => {
-                    alert('Error uploading CSV: ' + error.message);
+                    if (error) alert('Error uploading CSV: ' + error.message);
                 });
         });
 


### PR DESCRIPTION
## Summary
- add `ValidationErrorDTO` for bulk validations
- implement validation logic in `StockMovementService`
- expose validation endpoints in `StockMovementController`
- update admin stock movement page to validate entries before saving

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861b96866588327b843f472388b492b