### PR TITLE
Fix duplicate notifications

### DIFF
--- a/src/main/java/dev/oasis/stockify/service/StockMovementService.java
+++ b/src/main/java/dev/oasis/stockify/service/StockMovementService.java
@@ -354,8 +354,6 @@ public class StockMovementService {
                 dto.setNotes(nextLine.length > 3 ? nextLine[3] : null);
                 // Gerekirse diğer alanlar
                 createStockMovement(dto);
-                productRepository.findById(dto.getProductId())
-                        .ifPresent(stockNotificationService::checkAndCreateLowStockNotification);
                 count++;
             }
         }


### PR DESCRIPTION
## Summary
- stop calling checkAndCreateLowStockNotification twice when importing CSV

## Testing
- `./mvnw -q test` *(fails: Could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6861be722258832797cd42c9d88a3372