### PR TITLE
Fix duplicate notifications

### DIFF
--- a/src/main/java/dev/oasis/stockify/repository/StockNotificationRepository.java
+++ b/src/main/java/dev/oasis/stockify/repository/StockNotificationRepository.java
@@ -1,6 +1,7 @@
 package dev.oasis.stockify.repository;
 
 import dev.oasis.stockify.model.StockNotification;
+import dev.oasis.stockify.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,8 @@ import java.util.List;
 public interface StockNotificationRepository extends JpaRepository<StockNotification, Long> {
     List<StockNotification> findByReadFalseOrderByCreatedAtDesc();
     List<StockNotification> findAllByOrderByCreatedAtDesc();
+
+    boolean existsByProductAndReadFalse(Product product);
     
     @Modifying
     @Query("UPDATE StockNotification n SET n.read = true, n.readAt = CURRENT_TIMESTAMP WHERE n.read = false")

--- a/src/main/java/dev/oasis/stockify/service/StockNotificationService.java
+++ b/src/main/java/dev/oasis/stockify/service/StockNotificationService.java
@@ -27,6 +27,12 @@ public class StockNotificationService {
     @Transactional
     public void checkAndCreateLowStockNotification(Product product) {
         if (product.isLowStock()) {
+            boolean exists = notificationRepository.existsByProductAndReadFalse(product);
+            if (exists) {
+                logger.debug("Low stock notification already exists for product: {}", product.getTitle());
+                return;
+            }
+
             StockNotification notification = new StockNotification();
             notification.setProduct(product);
             notification.setMessage(String.format("'%s' ürününün stok seviyesi düşük! Mevcut stok: %d, Eşik: %d",


### PR DESCRIPTION
## Summary
- avoid duplicate stock notifications by checking existing unread notification
- expose repository method to query unread notification for a product

## Testing
- `./mvnw -q -DskipTests install` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861c0cf91d48327b2ae59a0368ac7e5