### PR TITLE
Fix stock movement UI script duplication

### DIFF
--- a/src/main/resources/templates/user/stock-movements.html
+++ b/src/main/resources/templates/user/stock-movements.html
@@ -468,13 +468,6 @@
                 .catch(error => { if (error) alert('Error creating stock movement: ' + error.message); });
         }
 
-        function addBulkRow() {
-            const table = document.getElementById('bulkMovementTable').getElementsByTagName('tbody')[0];
-            const newRow = table.rows[0].cloneNode(true);
-            Array.from(newRow.querySelectorAll('input, select')).forEach(el => el.value = '');
-            table.appendChild(newRow);
-        }
-
         function removeBulkRow(btn) {
             const row = btn.closest('tr');
             const table = row.parentNode;


### PR DESCRIPTION
## Summary
- remove redundant `addBulkRow` script in user stock movements page

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68627e773a348327b5dabe4213e84886